### PR TITLE
Add "Slovyansk" as incorrect spelling of "Sloviansk"

### DIFF
--- a/data/vocabulary/places/sloviansk.json
+++ b/data/vocabulary/places/sloviansk.json
@@ -3,7 +3,8 @@
   "sourceSpelling": "Слов'янськ",
   "correctSpelling": "Sloviansk",
   "incorrectSpellings": [
-    "Slavyansk"
+    "Slavyansk",
+    "Slovyansk"
   ],
   "relatedSpellings": [
     "Славянск"


### PR DESCRIPTION
I assume this _y_ spelling is deprecated.  I see it in many places, e.g., [Google Maps](https://www.google.com/maps/place/Slovyansk,+Donetsk+Oblast,+Ukraine/).